### PR TITLE
Allow sorting more items in SchemaPrinter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v15.1.0
+
+### Added
+
+- Add additional sorting options to `SchemaPrinter`
+
 ## v15.0.3
 
 ### Fixed

--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -2521,7 +2521,15 @@ static function concatAST(array $documents): GraphQL\Language\AST\DocumentNode
 
 Prints the contents of a Schema in schema definition language.
 
-@phpstan-type Options array{sortTypes?: bool}
+All sorting options sort alphabetically. If not given or `false`, the original schema definition order will be used.
+
+@phpstan-type Options array{
+sortArguments?: bool,
+sortEnumValues?: bool,
+sortFields?: bool,
+sortInputFields?: bool,
+sortTypes?: bool,
+}
 
 ### GraphQL\Utils\SchemaPrinter Methods
 

--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -2521,15 +2521,7 @@ static function concatAST(array $documents): GraphQL\Language\AST\DocumentNode
 
 Prints the contents of a Schema in schema definition language.
 
-All sorting options sort alphabetically. If not given or `false`, the original schema definition order will be used.
-
-@phpstan-type Options array{
-sortArguments?: bool,
-sortEnumValues?: bool,
-sortFields?: bool,
-sortInputFields?: bool,
-sortTypes?: bool,
-}
+@phpstan-type Options array{sortTypes?: bool}
 
 ### GraphQL\Utils\SchemaPrinter Methods
 


### PR DESCRIPTION
This change allows you to configure the SchemaPrinter and define what should be sorted and what not.

`sortArguments` allows to sort arguments used in fields on objects and interfaces.

`sortFields` allows to sort fields inside objects and interfaces.

`sortInputFields` allows to sort fields inside input objects.

`sortEnumValues` allows to sort enum values.

It's important to know that changing the order of fields inside input objects can have severe
consequences for clients that have generated code based on that order. For example, Apollo for
Kotlin and Swift takes the ordering from the input object to create the input objects.

When the order in the schema changes, so does the order of the constructor arguments for those
objects. When the calling code doesn't use named arguments, they can pass wrong values.

That's why I made sorting of input object fields a separate option.